### PR TITLE
Making the criteria for error response codes configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ implementation on your classpath. In that case just:
 
 Now you can create client proxies in apps where you don't want or need any server side component of JAX-RS.
 
+For more background information check out our [Engineering Blog](http://opower.github.io/2015/01/30/rest-client-tools/).
 
 ######Features
 
@@ -68,23 +69,23 @@ Here is an example of a resource interface. Note that it's simply a java interfa
  Here is a server side resource implementation example:
  
     public class FrobServerResource implments FrobResource {
-      // notice there are no JAX-RX annotations here. That is because
-      // the annotations belong on the interface ONLY. In some cases this
-      // can cause your endpoints to not function correctly. Or if you only put
-      // an annotation here and its missing from the interface, your clients won't
-      // function correctly since they don't have access to your server side resources
-      public Frob updateFrob(String frobId, String name) {
-          // do work here probably with dao and stuff
-      }
-       
-      public Frob findFrob(String frobId) {
-          // find frob work here
-      }
-   
-      public Response createFrob(Frob frob) {
-          // do more work
-      }
-  }
+        // notice there are no JAX-RX annotations here. That is because
+        // the annotations belong on the interface ONLY. In some cases this
+        // can cause your endpoints to not function correctly. Or if you only put
+        // an annotation here and its missing from the interface, your clients won't
+        // function correctly since they don't have access to your server side resources
+        public Frob updateFrob(String frobId, String name) {
+           // do work here probably with dao and stuff
+        }
+
+        public Frob findFrob(String frobId) {
+           // find frob work here
+        }
+
+        public Response createFrob(Frob frob) {
+            // do more work
+        }
+    }
    
  
   Once you have imported the Client.Builder you can use its fluent interface to create and customize a proxy instance for a given resource interface. 
@@ -94,9 +95,8 @@ Here is an example of a resource interface. Note that it's simply a java interfa
   They wrap calls in HystrixCommands to gives you circuit breaker protection.
   The rest-client-tools proxy builder requires a UriProvider implementation that tells clients how to find a service instance.
   
-    Client.Builder<FrobResource> clientBuilder = new Client.Builder<>(FrobResource.class, serviceDiscovery, serviceName, OAUTH_CLIENT_ID)
-                              .clientSecret(OAUTH_CLIENT_SECRET) // by specifying the oauth2 client secret, 
-                                                                 // you enable the auth-service integration
+    Client.Builder<FrobResource> clientBuilder = new Client.Builder<>(FrobResource.class, serviceDiscovery, serviceName, OAUTH_CLIENT_ID);
+
                               
   You may need to alter the proxy's requests before they are sent. For instance, you may need to add a header or some other parameter to the request.
   
@@ -114,7 +114,7 @@ Here is an example of a resource interface. Note that it's simply a java interfa
   
     List<ClientErrorInterceptor> interceptors = ImmutableList.<ClientErrorInterceptor>of(new ClientErrorInterceptor() {
               @Override
-              public void handle(ClientResponse<?> response) throws RuntimeException {
+              public void handle(ClientResponse response) throws RuntimeException {
                   // handle the error response as you see fit
                   throw new SpecialException(response.getResponseStatus());
               }
@@ -126,7 +126,7 @@ Here is an example of a resource interface. Note that it's simply a java interfa
   
     JacksonJsonProvider jsonProvider = new JacksonJsonProvider();
      
-    clientBuilder.messageBodyProviders(jsonProvider, jsonProvider);
+    clientBuilder.registerProviderInstance(jsonProvider);
  
  
   Client proxy instances require a ClientExecutor instance that will actually perform the http requests.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,22 @@ Here is an example of a resource interface. Note that it's simply a java interfa
           };
    
     clientBuilder.addClientRequestFilter(filter); // filters are applied in the order they are added.
-  
+
+  By default, http response codes between 400 (Bad Request) and 599 (Network Connect Timeout) are considered errors and
+  cause a ClientResponseFailure to be thrown. In some cases you may want certain response codes to not be treated as an Exception.
+  For example, you might have an endpoint for checking for an item in inventory and want to have it return 404 if no
+  inventory is available. In such a case you can use a custom errorStatusCriteria.
+
+    // The Predicate specifies which status codes should result in a ClientResponseFailure
+    Predicate<Integer> criteria = new Predicate<Integer>() {
+            @Override
+            public boolean apply(Integer status) {
+                return 404 != status && status >= BAD_REQUEST && status <= NETWORK_CONNECT_TIMEOUT;
+            }
+        };
+
+    clientBuilder.errorStatusCriteria(criteria);
+
   ClientErrorInterceptor defines the proxy's behavior in case of errors. Here is how you would specify your own list of custom ClientErrorInterceptors.
   
     List<ClientErrorInterceptor> interceptors = ImmutableList.<ClientErrorInterceptor>of(new ClientErrorInterceptor() {

--- a/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/ClientInvoker.java
+++ b/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/ClientInvoker.java
@@ -87,7 +87,7 @@ public class ClientInvoker implements MethodInvoker {
         uri.uri(baseUriProvider.getUri());
         if (declaring.isAnnotationPresent(Path.class)) uri.path(declaring);
         if (method.isAnnotationPresent(Path.class)) uri.path(method);
-        ClientRequest request = new ClientRequest(uri, executor, proxyConfig);
+        ClientRequest request = new ClientRequest(uri, executor, proxyConfig, method);
         if (accepts != null) request.header(HttpHeaders.ACCEPT, accepts.toString());
 
         boolean isClientResponseResult = ClientResponse.class.isAssignableFrom(method.getReturnType());

--- a/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/ClientRequest.java
+++ b/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/ClientRequest.java
@@ -14,6 +14,7 @@
  **/
 package com.opower.rest.client.generator.core;
 
+import com.google.common.base.Predicate;
 import com.opower.rest.client.generator.specimpl.MultivaluedMapImpl;
 import com.opower.rest.client.generator.specimpl.UriBuilderImpl;
 import com.opower.rest.client.generator.util.Encode;
@@ -30,6 +31,7 @@ import javax.ws.rs.ext.Providers;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +51,7 @@ import java.util.Map;
 @SuppressWarnings("unchecked")
 public class ClientRequest implements Cloneable {
     private final ProxyConfig proxyConfig;
+    private final Method method;
     protected UriBuilderImpl uri;
     protected ClientExecutor executor;
     protected MultivaluedMap<String, Object> headers;
@@ -66,14 +69,15 @@ public class ClientRequest implements Cloneable {
     protected String finalUri;
     protected List<String> pathParameterList;
 
-    public ClientRequest(String uriTemplate, ClientExecutor executor, ProxyConfig proxyConfig) {
-        this((UriBuilderImpl) new UriBuilderImpl().uriTemplate(uriTemplate), executor, proxyConfig);
+    public ClientRequest(String uriTemplate, ClientExecutor executor, ProxyConfig proxyConfig, Method method) {
+        this((UriBuilderImpl) new UriBuilderImpl().uriTemplate(uriTemplate), executor, proxyConfig, method);
     }
 
-    public ClientRequest(UriBuilderImpl uriBuilder, ClientExecutor executor, ProxyConfig proxyConfig) {
+    public ClientRequest(UriBuilderImpl uriBuilder, ClientExecutor executor, ProxyConfig proxyConfig, Method method) {
         this.uri = uriBuilder;
         this.executor = executor;
         this.proxyConfig = proxyConfig;
+        this.method = method;
     }
 
     public boolean followRedirects() {
@@ -230,6 +234,10 @@ public class ClientRequest implements Cloneable {
 
     public String getHttpMethod() {
         return httpMethod;
+    }
+
+    public Predicate<Integer> getErrorStatusCriteria() {
+        return this.proxyConfig.getErrorStatusCriteria().get(this.method);
     }
 
     public ClientResponse execute(String httpMethod) throws Exception {

--- a/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/ProxyConfig.java
+++ b/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/ProxyConfig.java
@@ -15,30 +15,36 @@
 package com.opower.rest.client.generator.core;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.opower.rest.client.generator.extractors.EntityExtractorFactory;
 
 import javax.ws.rs.ext.Providers;
+import java.lang.reflect.Method;
 import java.util.List;
+import java.util.concurrent.ConcurrentMap;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ProxyConfig {
+
     private final ClassLoader loader;
     private final ClientExecutor executor;
     private final Providers providers;
     private final EntityExtractorFactory extractorFactory;
     private final List<ClientErrorInterceptor> clientErrorInterceptors;
+    private final ConcurrentMap<Method, Predicate<Integer>> errorStatusCriteria;
 
     public ProxyConfig(ClassLoader loader, ClientExecutor executor, Providers providers,
-                       EntityExtractorFactory extractorFactory, List<ClientErrorInterceptor> clientErrorInterceptors) {
+                       EntityExtractorFactory extractorFactory, List<ClientErrorInterceptor> clientErrorInterceptors,
+                       ConcurrentMap<Method, Predicate<Integer>> errorStatusCriteria) {
         this.loader = checkNotNull(loader);
         this.executor = checkNotNull(executor);
         this.providers = checkNotNull(providers);
         this.extractorFactory = checkNotNull(extractorFactory);
         this.clientErrorInterceptors = Optional.fromNullable(clientErrorInterceptors).or(Lists.<ClientErrorInterceptor>newArrayList());
+        this.errorStatusCriteria = checkNotNull(errorStatusCriteria);
     }
-
 
     public ClassLoader getLoader() {
         return loader;
@@ -60,4 +66,7 @@ public class ProxyConfig {
         return clientErrorInterceptors;
     }
 
+    public ConcurrentMap<Method, Predicate<Integer>> getErrorStatusCriteria() {
+        return errorStatusCriteria;
+    }
 }

--- a/rest-client-generator/src/main/java/com/opower/rest/client/generator/executors/ApacheHttpClient4Executor.java
+++ b/rest-client-generator/src/main/java/com/opower/rest/client/generator/executors/ApacheHttpClient4Executor.java
@@ -110,7 +110,8 @@ public class ApacheHttpClient4Executor extends AbstractClientExecutor {
 
         final HttpResponse res = this.httpClient.execute(httpMethod, this.httpContext);
 
-        BaseClientResponse response = new BaseClientResponse(new SimpleBaseClientResponseStreamFactory(res), this);
+        BaseClientResponse response = new BaseClientResponse(new SimpleBaseClientResponseStreamFactory(res), this,
+                                                             request.getErrorStatusCriteria());
 
         response.setStatus(res.getStatusLine().getStatusCode());
         response.setHeaders(extractHeaders(res));

--- a/rest-client-generator/src/main/java/com/opower/rest/client/generator/executors/AsyncHttpClientExecutor.java
+++ b/rest-client-generator/src/main/java/com/opower/rest/client/generator/executors/AsyncHttpClientExecutor.java
@@ -87,7 +87,8 @@ public class AsyncHttpClientExecutor extends AbstractClientExecutor {
 
         Response rawResponse = this.httpClient.executeRequest(requestBuilder.build()).get();
 
-        BaseClientResponse response = new BaseClientResponse(new SimpleBaseClientResponseStreamFactory(rawResponse), this);
+        BaseClientResponse response = new BaseClientResponse(new SimpleBaseClientResponseStreamFactory(rawResponse), this,
+                                                             request.getErrorStatusCriteria());
 
         response.setStatus(rawResponse.getStatusCode());
         response.setHeaders(extractHeaders(rawResponse));

--- a/rest-client-generator/src/test/java/com/opower/rest/client/generator/core/TestBaseClientResponse.java
+++ b/rest-client-generator/src/test/java/com/opower/rest/client/generator/core/TestBaseClientResponse.java
@@ -2,15 +2,63 @@ package com.opower.rest.client.generator.core;
 
 import java.io.IOException;
 import java.io.InputStream;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import org.junit.Test;
 
+import static com.opower.rest.client.generator.core.Client.DEFAULT_ERROR_STATUS_CRITERIA;
+import static com.opower.rest.client.generator.core.Client.BAD_REQUEST;
+import static com.opower.rest.client.generator.core.Client.NETWORK_CONNECT_TIMEOUT;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * @author chris.phillips
  */
 public class TestBaseClientResponse {
+
+    private static final int SC_OK = 200;
+    private static final int END_OF_REDIRECTION_RANGE = 399;
+
+    /**
+     * Verifies that the Client.DEFAULT_ERROR_STATUS_CRITERIA works as expected.
+     */
+    @Test
+    public void defaultErrorStatusCriteria() {
+
+        Predicate<Integer> t = new Predicate<Integer>() {
+            @Override
+            public boolean apply(Integer status) {
+                return 404 != status && status >= BAD_REQUEST && status <= NETWORK_CONNECT_TIMEOUT;
+            }
+        };
+
+        BaseClientResponse blah = new BaseClientResponse(null, t);
+        blah.setStatus(404);
+        blah.checkFailureStatus();
+
+        BaseClientResponse response = new BaseClientResponse(null, DEFAULT_ERROR_STATUS_CRITERIA);
+        for (int i = BAD_REQUEST; i <= NETWORK_CONNECT_TIMEOUT; i++) {
+            try {
+                response.setStatus(i);
+                response.checkFailureStatus();
+                fail();
+            } catch(ClientResponseFailure clientResponseFailure) {}
+        }
+
+        for (int i = SC_OK; i <= END_OF_REDIRECTION_RANGE; i++) {
+            try {
+                response.setStatus(i);
+                response.checkFailureStatus();
+            } catch(ClientResponseFailure clientResponseFailure) {
+                fail();
+            }
+        }
+    }
+
+
 
     /**
      * When resetting the stream if an exception is thrown, it should be caught and resetStream should return false.
@@ -34,7 +82,7 @@ public class TestBaseClientResponse {
             public void performReleaseConnection() {
 
             }
-        });
+        }, DEFAULT_ERROR_STATUS_CRITERIA);
 
         assertThat(response.resetStream(), is(false));
     }
@@ -64,7 +112,7 @@ public class TestBaseClientResponse {
             public void performReleaseConnection() {
 
             }
-        });
+        }, DEFAULT_ERROR_STATUS_CRITERIA);
 
         assertThat(response.resetStream(), is(true));
     }

--- a/rest-client-generator/src/test/java/com/opower/rest/client/generator/core/TestClientRequest.java
+++ b/rest-client-generator/src/test/java/com/opower/rest/client/generator/core/TestClientRequest.java
@@ -20,7 +20,7 @@ public class TestClientRequest {
 
     @Before
     public void setUp() {
-        request = new ClientRequest("http://dummy", null, null);
+        request = new ClientRequest("http://dummy", null, null, null);
     }
 
     @Test


### PR DESCRIPTION
Currently rest-client-tools treats all response codes between 400 and 599 as errors and throws an exception. We should make it so that the criteria for determining whether or not a status code causes an exception is configurable per method on the resource interface.