### PR TITLE
Allow wrapping of some Exceptions to HystrixBadRequestException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -777,6 +777,29 @@
                         </configuration>
                         <executions>
                             <execution>
+                                <id>int-tests</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <!--<debugForkedProcess>true</debugForkedProcess>-->
+                                    <includes>
+                                        <include>**/*IntTest.java</include>
+                                    </includes>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExcludes>javax.ws.rs:jsr311-api</classpathDependencyExcludes>
+                                        <classpathDependencyExcludes>javax.ws.rs:javax.ws.rs-api</classpathDependencyExcludes>
+                                        <classpathDependencyExcludes>org.glassfish.jersey.core:jersey-common</classpathDependencyExcludes>
+                                    </classpathDependencyExcludes>
+                                    <skipTests>false</skipTests>
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${settings.localRepository}/com/sun/jersey/jersey-core/1.17.1/jersey-core-1.17.1.jar</additionalClasspathElement>
+                                        <additionalClasspathElement>${settings.localRepository}/com/sun/jersey/jersey-server/1.17.1/jersey-server-1.17.1.jar</additionalClasspathElement>
+                                        <additionalClasspathElement>${settings.localRepository}/com/sun/jersey/jersey-servlet/1.17.1/jersey-servlet-1.17.1.jar</additionalClasspathElement>
+                                    </additionalClasspathElements>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>jersey-1.17.1</id>
                                 <goals>
                                     <goal>test</goal>

--- a/rest-client-generator/pom.xml
+++ b/rest-client-generator/pom.xml
@@ -30,32 +30,6 @@
                         <additionalClasspathElement>${settings.localRepository}/javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.jar</additionalClasspathElement>
                     </additionalClasspathElements>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>error-handling</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <!--<debugForkedProcess>true</debugForkedProcess>-->
-                            <includes>
-                                <include>**/*IntTest.java</include>
-                            </includes>
-                            <classpathDependencyExcludes>
-                                <classpathDependencyExcludes>javax.ws.rs:jsr311-api</classpathDependencyExcludes>
-                                <classpathDependencyExcludes>javax.ws.rs:javax.ws.rs-api</classpathDependencyExcludes>
-                                <classpathDependencyExcludes>org.glassfish.jersey.core:jersey-common</classpathDependencyExcludes>
-                            </classpathDependencyExcludes>
-                            <skipTests>false</skipTests>
-                            <additionalClasspathElements>
-                                <additionalClasspathElement>${settings.localRepository}/com/sun/jersey/jersey-core/1.17.1/jersey-core-1.17.1.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${settings.localRepository}/com/sun/jersey/jersey-server/1.17.1/jersey-server-1.17.1.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${settings.localRepository}/com/sun/jersey/jersey-servlet/1.17.1/jersey-servlet-1.17.1.jar</additionalClasspathElement>
-                            </additionalClasspathElements>
-                            <test>com.opower.rest.test.ClientErrorHandlingIntTest</test>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/BaseClientResponse.java
+++ b/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/BaseClientResponse.java
@@ -334,6 +334,10 @@ public class BaseClientResponse extends ClientResponse {
         }
     }
 
+    public boolean isSuccessful() {
+        return !this.errorStatusCriteria.apply(this.getStatus());
+    }
+
     public ClientResponseFailure createResponseFailure(String message) {
         return createResponseFailure(message, null);
     }

--- a/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/ProxyConfig.java
+++ b/rest-client-generator/src/main/java/com/opower/rest/client/generator/core/ProxyConfig.java
@@ -14,14 +14,12 @@
  **/
 package com.opower.rest.client.generator.core;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
-import com.google.common.collect.Lists;
+import com.opower.rest.client.generator.extractors.ClientErrorHandler;
 import com.opower.rest.client.generator.extractors.EntityExtractorFactory;
 
 import javax.ws.rs.ext.Providers;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -32,18 +30,20 @@ public class ProxyConfig {
     private final ClientExecutor executor;
     private final Providers providers;
     private final EntityExtractorFactory extractorFactory;
-    private final List<ClientErrorInterceptor> clientErrorInterceptors;
     private final ConcurrentMap<Method, Predicate<Integer>> errorStatusCriteria;
 
+    private final ClientErrorHandler clientErrorHandler;
+
     public ProxyConfig(ClassLoader loader, ClientExecutor executor, Providers providers,
-                       EntityExtractorFactory extractorFactory, List<ClientErrorInterceptor> clientErrorInterceptors,
-                       ConcurrentMap<Method, Predicate<Integer>> errorStatusCriteria) {
+                       EntityExtractorFactory extractorFactory,
+                       ConcurrentMap<Method, Predicate<Integer>> errorStatusCriteria,
+                       ClientErrorHandler clientErrorHandler) {
         this.loader = checkNotNull(loader);
         this.executor = checkNotNull(executor);
         this.providers = checkNotNull(providers);
         this.extractorFactory = checkNotNull(extractorFactory);
-        this.clientErrorInterceptors = Optional.fromNullable(clientErrorInterceptors).or(Lists.<ClientErrorInterceptor>newArrayList());
         this.errorStatusCriteria = checkNotNull(errorStatusCriteria);
+        this.clientErrorHandler = checkNotNull(clientErrorHandler);
     }
 
     public ClassLoader getLoader() {
@@ -62,8 +62,8 @@ public class ProxyConfig {
         return extractorFactory;
     }
 
-    public List<ClientErrorInterceptor> getClientErrorInterceptors() {
-        return clientErrorInterceptors;
+    public ClientErrorHandler getClientErrorHandler() {
+        return clientErrorHandler;
     }
 
     public ConcurrentMap<Method, Predicate<Integer>> getErrorStatusCriteria() {

--- a/rest-client-generator/src/main/java/com/opower/rest/client/generator/extractors/ClientErrorHandler.java
+++ b/rest-client-generator/src/main/java/com/opower/rest/client/generator/extractors/ClientErrorHandler.java
@@ -1,69 +1,14 @@
-/**
- *    Copyright 2014 Opower, Inc.
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- **/
 package com.opower.rest.client.generator.extractors;
 
-import com.google.common.collect.Lists;
 import com.opower.rest.client.generator.core.BaseClientResponse;
-import com.opower.rest.client.generator.core.ClientErrorInterceptor;
-import com.opower.rest.client.generator.core.ClientResponseFailure;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
+import java.lang.reflect.Method;
 
 /**
- * This class handles client errors (of course...).
- *
- * @author Solomon.Duskis
+ * Implementations of this class handle the various errors both client and server side that can occur as a result of
+ * making REST calls.
+ * @author chris.phillips
  */
-
-// TODO: expand this class for more robust, complicated error handling
-
-public class ClientErrorHandler {
-    private static final Logger LOG = LoggerFactory.getLogger(ClientErrorHandler.class);
-    private List<ClientErrorInterceptor> interceptors = Lists.newArrayList();
-
-    public ClientErrorHandler(List<ClientErrorInterceptor> interceptors) {
-        this.interceptors = interceptors;
-    }
-
-    @SuppressWarnings("unchecked")
-    public void clientErrorHandling(BaseClientResponse clientResponse, RuntimeException e) {
-
-        // Only ClientResponseFailures represent an error response from the server
-        // so only such exceptions should be handled by the ClientErrorInterceptors
-        if(e instanceof ClientResponseFailure) {
-            for (ClientErrorInterceptor handler : interceptors) {
-                try {
-                    // attempt to reset the stream in order to provide a fresh stream
-                    // to each ClientErrorInterceptor -- failing to reset the stream
-                    // could mean that an unusable stream will be passed to the
-                    // interceptor
-                    InputStream stream = clientResponse.getStreamFactory().getInputStream();
-                    if (stream != null) {
-                        stream.reset();
-                    }
-                } catch (IOException e1) {
-                    LOG.warn("problem while handling errors", e1);
-                }
-                handler.handle(clientResponse);
-            }
-        }
-
-        throw e;
-    }
+public interface ClientErrorHandler {
+    void clientErrorHandling(Method method, BaseClientResponse clientResponse, RuntimeException e);
 }

--- a/rest-client-generator/src/main/java/com/opower/rest/client/generator/extractors/DefaultClientErrorHandler.java
+++ b/rest-client-generator/src/main/java/com/opower/rest/client/generator/extractors/DefaultClientErrorHandler.java
@@ -1,0 +1,76 @@
+/**
+ *    Copyright 2014 Opower, Inc.
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ **/
+package com.opower.rest.client.generator.extractors;
+
+import com.google.common.base.Optional;
+import com.opower.rest.client.generator.core.BaseClientResponse;
+import com.opower.rest.client.generator.core.ClientErrorInterceptor;
+import com.opower.rest.client.generator.core.ClientResponseFailure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class handles client errors (of course...).
+ *
+ * @author Solomon.Duskis
+ */
+
+// TODO: expand this class for more robust, complicated error handling
+
+public class DefaultClientErrorHandler implements ClientErrorHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultClientErrorHandler.class);
+    private final List<ClientErrorInterceptor> interceptors;
+
+    public DefaultClientErrorHandler(List<ClientErrorInterceptor> interceptors) {
+        this.interceptors = Optional.fromNullable(interceptors).or(new ArrayList<ClientErrorInterceptor>());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void clientErrorHandling(Method method, BaseClientResponse clientResponse, RuntimeException e) {
+        // Only ClientResponseFailures represent an error response from the server
+        // so only such exceptions should be handled by the ClientErrorInterceptors
+        if (e instanceof ClientResponseFailure) {
+            for (ClientErrorInterceptor handler : interceptors) {
+                try {
+                    // attempt to reset the stream in order to provide a fresh stream
+                    // to each ClientErrorInterceptor -- failing to reset the stream
+                    // could mean that an unusable stream will be passed to the
+                    // interceptor
+                    InputStream stream = clientResponse.getStreamFactory().getInputStream();
+                    if (stream != null) {
+                        stream.reset();
+                    }
+                } catch (IOException e1) {
+                    LOG.warn("problem while handling errors", e1);
+                }
+                handler.handle(clientResponse);
+            }
+        } else {
+            String status = clientResponse == null ? "null" : Integer.toString(clientResponse.getStatus());
+            LOG.warn("The HTTP request was successful and retuned a status of {}. However, there was a problem processing " +
+                     "the response on the client side. Usually this is a deserialization problem, check the configuration " +
+                     "of your MessageBodyReader.", status);
+        }
+
+        throw e;
+    }
+}

--- a/rest-client-generator/src/test/java/com/opower/rest/client/generator/core/TestBaseClientResponse.java
+++ b/rest-client-generator/src/test/java/com/opower/rest/client/generator/core/TestBaseClientResponse.java
@@ -4,12 +4,13 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import org.junit.Test;
 
 import static com.opower.rest.client.generator.core.Client.DEFAULT_ERROR_STATUS_CRITERIA;
-import static com.opower.rest.client.generator.core.Client.BAD_REQUEST;
 import static com.opower.rest.client.generator.core.Client.NETWORK_CONNECT_TIMEOUT;
+import static com.opower.rest.client.generator.util.HttpResponseCodes.SC_BAD_REQUEST;
+import static com.opower.rest.client.generator.util.HttpResponseCodes.SC_OK;
+import static com.opower.rest.client.generator.util.HttpResponseCodes.SC_NOT_FOUND;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -19,7 +20,6 @@ import static org.junit.Assert.fail;
  */
 public class TestBaseClientResponse {
 
-    private static final int SC_OK = 200;
     private static final int END_OF_REDIRECTION_RANGE = 399;
 
     /**
@@ -31,7 +31,7 @@ public class TestBaseClientResponse {
         Predicate<Integer> t = new Predicate<Integer>() {
             @Override
             public boolean apply(Integer status) {
-                return 404 != status && status >= BAD_REQUEST && status <= NETWORK_CONNECT_TIMEOUT;
+                return SC_NOT_FOUND != status && status >= SC_BAD_REQUEST && status <= NETWORK_CONNECT_TIMEOUT;
             }
         };
 
@@ -40,7 +40,7 @@ public class TestBaseClientResponse {
         blah.checkFailureStatus();
 
         BaseClientResponse response = new BaseClientResponse(null, DEFAULT_ERROR_STATUS_CRITERIA);
-        for (int i = BAD_REQUEST; i <= NETWORK_CONNECT_TIMEOUT; i++) {
+        for (int i = SC_BAD_REQUEST; i <= NETWORK_CONNECT_TIMEOUT; i++) {
             try {
                 response.setStatus(i);
                 response.checkFailureStatus();

--- a/rest-client-hystrix/pom.xml
+++ b/rest-client-hystrix/pom.xml
@@ -36,8 +36,22 @@
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
             <version>1.1.1</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>${settings.localRepository}/javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.jar</additionalClasspathElement>
+                    </additionalClasspathElements>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/rest-client-hystrix/src/main/java/com/opower/rest/client/generator/hystrix/HystrixClientErrorHandler.java
+++ b/rest-client-hystrix/src/main/java/com/opower/rest/client/generator/hystrix/HystrixClientErrorHandler.java
@@ -1,0 +1,91 @@
+package com.opower.rest.client.generator.hystrix;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import com.opower.rest.client.generator.core.BaseClientResponse;
+import com.opower.rest.client.generator.extractors.ClientErrorHandler;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.opower.rest.client.generator.util.HttpResponseCodes.SC_BAD_REQUEST;
+
+/**
+ * Certain responses should be treated as HystrixBadRequestExceptions. By default only requests with a response
+ * code of 400 will be handled this way. To change that behavior, just specify new criteria for any method
+ * in your resource interface.
+ *
+ * @author chris.phillips
+ */
+public class HystrixClientErrorHandler implements ClientErrorHandler {
+
+    static final BadRequestCriteria DEFAULT_BAD_REQUEST_CRITERIA = new BadRequestCriteria() {
+        @Override
+        public boolean apply(BaseClientResponse response, Exception exception) {
+            return response != null && response.getStatus() == SC_BAD_REQUEST;
+        }
+    };
+
+    private final ClientErrorHandler clientErrorHandler;
+    private final Map<Method, ? extends BadRequestCriteria> badRequestCriteriaMap;
+
+    /**
+     * Creates an instance based on the provided ClientErrorHandler and bad request criteria.
+     * @param badRequestCriteriaMap the bad request criteria to apply for each method
+     * @param clientErrorHandler the ClientErrorHandler to wrap
+     */
+    public HystrixClientErrorHandler(Map<Method, ? extends BadRequestCriteria> badRequestCriteriaMap,
+                                     ClientErrorHandler clientErrorHandler) {
+        this.clientErrorHandler = checkNotNull(clientErrorHandler);
+        this.badRequestCriteriaMap = checkNotNull(badRequestCriteriaMap);
+    }
+
+    @Override
+    public void clientErrorHandling(Method method, BaseClientResponse clientResponse, RuntimeException e) {
+        try {
+            this.clientErrorHandler.clientErrorHandling(method, clientResponse, e);
+            checkForBadRequest(method, clientResponse, e);
+        } catch (Exception ex) {
+            checkForBadRequest(method, clientResponse, ex);
+        }
+    }
+
+    private void checkForBadRequest(Method method, BaseClientResponse clientResponse, Exception ex) {
+        BadRequestCriteria criteria;
+        if (method != null) {
+            criteria = Optional.fromNullable(this.badRequestCriteriaMap.get(method)).or(DEFAULT_BAD_REQUEST_CRITERIA);
+        } else {
+            criteria = DEFAULT_BAD_REQUEST_CRITERIA;
+        }
+
+        if (criteria.apply(clientResponse, ex) || (clientResponse != null && clientResponse.isSuccessful())) {
+            throw new HystrixBadRequestException("Bad Request", ex);
+        } else {
+            Throwables.propagate(ex);
+        }
+    }
+
+    /**
+     * This method is for testing.
+     * @return the map of method -> BadRequestCriteria
+     */
+    Map<Method, ? extends BadRequestCriteria> getCriteriaMap() {
+        return this.badRequestCriteriaMap;
+    }
+
+    /**
+     * Defines which responses should be NOT trigger the hystrix circuit breaker.
+     */
+    public interface BadRequestCriteria {
+        /**
+         * Check the response and Exception to determine whether or not to wrap the Exception in a
+         * HystrixBadRequestException. When this method returns true, the Exception will be wrapped.
+         * @param response the response to check
+         * @param exception the exception to check
+         * @return true if the Exception should be wrapped in a HystrixBadRequestException
+         */
+        boolean apply(BaseClientResponse response, Exception exception);
+    }
+}

--- a/rest-client-hystrix/src/main/java/com/opower/rest/client/generator/hystrix/HystrixCommandInvocationHandler.java
+++ b/rest-client-hystrix/src/main/java/com/opower/rest/client/generator/hystrix/HystrixCommandInvocationHandler.java
@@ -15,6 +15,7 @@
 package com.opower.rest.client.generator.hystrix;
 
 import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
 import com.netflix.hystrix.exception.HystrixRuntimeException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -94,6 +95,8 @@ final class HystrixCommandInvocationHandler<T> implements InvocationHandler {
     static Object execute(HystrixCommand command) throws Throwable {
         try {
             return command.execute();
+        } catch (HystrixBadRequestException ex) {
+            throw ex.getCause();
         } catch (HystrixRuntimeException ex) {
             // fallback failures should always just throw the HystrixRuntimeException
             if (ex.getFallbackException() != null) {

--- a/rest-client-hystrix/src/main/java/com/opower/rest/client/generator/hystrix/ProxyCommand.java
+++ b/rest-client-hystrix/src/main/java/com/opower/rest/client/generator/hystrix/ProxyCommand.java
@@ -17,6 +17,8 @@ package com.opower.rest.client.generator.hystrix;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.netflix.hystrix.HystrixCommand;
+
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 
@@ -59,7 +61,11 @@ final class ProxyCommand extends HystrixCommand {
 
     @Override
     protected Object run() throws Exception {
-        return this.toinvoke.invoke(this.target, this.args);
+        try {
+            return this.toinvoke.invoke(this.target, this.args);
+        } catch (InvocationTargetException ex) {
+            throw Throwables.propagate(ex.getTargetException());
+        }
     }
 
     @Override

--- a/rest-client-hystrix/src/test/java/com/opower/rest/client/generator/hystrix/HystrixErrorHandlingIntTest.java
+++ b/rest-client-hystrix/src/test/java/com/opower/rest/client/generator/hystrix/HystrixErrorHandlingIntTest.java
@@ -1,0 +1,122 @@
+package com.opower.rest.client.generator.hystrix;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.google.common.collect.ImmutableList;
+import com.netflix.hystrix.HystrixCommandMetrics;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+import com.opower.rest.client.ConfigurationCallback;
+import com.opower.rest.client.generator.core.ClientErrorInterceptor;
+import com.opower.rest.client.generator.core.ClientResponse;
+import com.opower.rest.client.generator.core.ResourceInterface;
+import com.opower.rest.client.generator.core.SimpleUriProvider;
+import com.opower.rest.client.generator.core.UriProvider;
+import com.opower.rest.client.generator.executors.ApacheHttpClient4Executor;
+import com.opower.rest.client.generator.util.HttpResponseCodes;
+import com.opower.rest.test.StatusCodeMatcher;
+import com.opower.rest.test.jetty.JettyRule;
+import com.opower.rest.test.resource.FrobResource;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static com.opower.rest.client.generator.hystrix.TestHystrixClientBuilder.GROUP_KEY;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author chris.phillips
+ */
+public class HystrixErrorHandlingIntTest {
+
+    private static int PORT = 7999;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .setDateFormat(new ISO8601DateFormat())
+            .registerModule(new GuavaModule())
+            .registerModule(new JodaModule());
+    private static final JacksonJsonProvider JACKSON_JSON_PROVIDER = new JacksonJsonProvider(OBJECT_MAPPER)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            // enabling this feature to make deserialization fail
+            .configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
+
+    @ClassRule
+    public static final JettyRule JETTY_RULE =
+            new JettyRule(PORT, HystrixErrorHandlingIntTest.class.getResource("/jersey/1/web.xml").toString());
+
+    private static final UriProvider URI_PROVIDER = new SimpleUriProvider(String.format("http://localhost:%s/", PORT));
+    private static final ResourceInterface<FrobResource> RESOURCE_INTERFACE = new ResourceInterface<>(FrobResource.class);
+
+    private FrobResource frobResource = new HystrixClient.Builder<FrobResource>(RESOURCE_INTERFACE, URI_PROVIDER, GROUP_KEY)
+                                            .clientErrorInterceptors(ImmutableList
+                                                    .<ClientErrorInterceptor>of(new TestClientErrorInterceptor()))
+            .commandProperties(new ConfigurationCallback<HystrixCommandProperties.Setter>() {
+                @Override
+                public void configure(HystrixCommandProperties.Setter setter) {
+                    setter.withExecutionIsolationThreadTimeoutInMilliseconds(10000);
+                }
+            })
+                                            .executor(new ApacheHttpClient4Executor())
+                                            .registerProviderInstance(JACKSON_JSON_PROVIDER).build();
+
+    /**
+     * Exceptions on the client side, even despite a successful http response, should always be propagated
+     * and shouldn't count towards circuit-breaker
+     * @throws Exception
+     */
+    @Test
+    public void nonClientResponseFailureThrowsOriginalException() throws Exception {
+        Method frobJsonErrorMethod = FrobResource.class.getMethod("frobJsonError");
+        try {
+            frobResource.frobJsonError();
+            fail();
+        } catch(RuntimeException ex) {
+            assertTrue(ex.getCause() instanceof JsonMappingException);
+            HystrixCommandMetrics metrics = HystrixCommandMetrics.getInstance(HystrixClient.keyForMethod(frobJsonErrorMethod));
+            assertThat(metrics.getCumulativeCount(HystrixRollingNumberEvent.FAILURE), is(0L));
+            assertThat(metrics.getCumulativeCount(HystrixRollingNumberEvent.EXCEPTION_THROWN), is(1L));
+        }
+    }
+
+    /**
+     * Ensures that the HystrixClientErrorHandler is properly wrapping exceptions in HystrixBadRequestExceptions. This is
+     * verified by checking the failure stats for the HystrixCommand.
+     * @throws Exception
+     */
+    @Test
+    public void serverResponseErrors() throws Exception {
+        Method frobErrorResponseMethod = FrobResource.class.getMethod("frobErrorResponse", int.class);
+        // this is an error that should trip the circuit-breaker so should up the FAILURE count
+        metricsTest(frobErrorResponseMethod, HttpResponseCodes.SC_INTERNAL_SERVER_ERROR, 1L, 1L);
+        // this is a bad request that should NOT trip the circuit break or up the FAILURE count
+        metricsTest(frobErrorResponseMethod, HttpResponseCodes.SC_BAD_REQUEST, 1L, 2L);
+    }
+
+    private void metricsTest(Method method, int statusCode, long expectedFailureCount, long expectedExceptionThrownCount) throws Exception {
+        try {
+            frobResource.frobErrorResponse(statusCode);
+            fail();
+        } catch(StatusCodeMatcher.ResponseError ex) {
+            HystrixCommandMetrics metrics = HystrixCommandMetrics.getInstance(HystrixClient.keyForMethod(method));
+            assertThat(ex.getClientResponse().getStatus(), is(statusCode));
+            assertThat(metrics.getCumulativeCount(HystrixRollingNumberEvent.FAILURE), is(expectedFailureCount));
+            assertThat(metrics.getCumulativeCount(HystrixRollingNumberEvent.EXCEPTION_THROWN), is(expectedExceptionThrownCount));
+        }
+    }
+
+    private class TestClientErrorInterceptor implements ClientErrorInterceptor {
+        @Override
+        public void handle(ClientResponse response) throws RuntimeException {
+            throw new StatusCodeMatcher.ResponseError(response);
+        }
+    }
+}

--- a/rest-client-hystrix/src/test/java/com/opower/rest/client/generator/hystrix/TestHystrixClientBuilder.java
+++ b/rest-client-hystrix/src/test/java/com/opower/rest/client/generator/hystrix/TestHystrixClientBuilder.java
@@ -1,0 +1,82 @@
+package com.opower.rest.client.generator.hystrix;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.opower.rest.client.generator.core.BaseClientResponse;
+import com.opower.rest.client.generator.core.ResourceInterface;
+import com.opower.rest.client.generator.core.SimpleUriProvider;
+import com.opower.rest.client.generator.core.UriProvider;
+import com.opower.rest.client.generator.hystrix.HystrixClientErrorHandler.BadRequestCriteria;
+import com.opower.rest.test.resource.FrobResource;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the HystrixClient.Builder.
+ * @author chris.phillips
+ */
+public class TestHystrixClientBuilder {
+
+    private static final UriProvider URI_PROVIDER = new SimpleUriProvider("http://localhost");
+    static final HystrixCommandGroupKey GROUP_KEY = HystrixCommandGroupKey.Factory.asKey("test");
+    private static final ResourceInterface<FrobResource> RESOURCE_INTERFACE = new ResourceInterface<>(FrobResource.class);
+    private static final Method FROB_METHOD = FrobResource.class.getMethods()[0];
+    private HystrixClient.Builder<FrobResource> builder = new HystrixClient.Builder<>(RESOURCE_INTERFACE, URI_PROVIDER, GROUP_KEY);
+    /**
+     * Initializes the system property to ensure the RuntimeDelegate gets properly loaded.
+     */
+    @BeforeClass
+    public static void init() {
+        System.setProperty("javax.ws.rs.ext.RuntimeDelegate","com.opower.rest.client.generator.core.BasicRuntimeDelegate");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullMethod() {
+        builder.methodBadRequestCriteria(null, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void wrongMethod() {
+        builder.methodBadRequestCriteria(TestHystrixClientBuilder.class.getMethods()[0], null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullCriteria() {
+        builder.methodBadRequestCriteria(FROB_METHOD, null);
+    }
+
+    @Test
+    public void setMethodCriteria() {
+        builder.methodBadRequestCriteria(FROB_METHOD, new BadRequestCriteria() {
+            @Override
+            public boolean apply(BaseClientResponse response, Exception exception) {
+                return false;
+            }
+        });
+        Map<Method, ? extends BadRequestCriteria> criteriaMap = ((HystrixClientErrorHandler)builder.getClientErrorHandler()).getCriteriaMap();
+        assertTrue(criteriaMap.containsKey(FROB_METHOD));
+        assertThat(criteriaMap.size(), is(1));
+    }
+
+    @Test
+    public void setResourceCriteria() {
+        builder.badRequestCriteria(new BadRequestCriteria() {
+            @Override
+            public boolean apply(BaseClientResponse response, Exception exception) {
+                return false;
+            }
+        });
+        Map<Method, ? extends BadRequestCriteria> criteriaMap = ((HystrixClientErrorHandler)builder.getClientErrorHandler()).getCriteriaMap();
+        Method[] methods = FrobResource.class.getMethods();
+        for (Method method : methods) {
+            assertTrue(criteriaMap.containsKey(method));
+        }
+        assertThat(criteriaMap.size(), is(methods.length));
+    }
+}

--- a/rest-client-hystrix/src/test/java/com/opower/rest/client/generator/hystrix/TestHystrixClientErrorHandler.java
+++ b/rest-client-hystrix/src/test/java/com/opower/rest/client/generator/hystrix/TestHystrixClientErrorHandler.java
@@ -1,0 +1,159 @@
+package com.opower.rest.client.generator.hystrix;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import com.opower.rest.client.generator.core.BaseClientResponse;
+import com.opower.rest.client.generator.core.Client;
+import com.opower.rest.client.generator.core.ClientResponseFailure;
+import com.opower.rest.client.generator.extractors.ClientErrorHandler;
+import com.opower.rest.client.generator.hystrix.HystrixClientErrorHandler.BadRequestCriteria;
+import com.opower.rest.client.generator.util.HttpResponseCodes;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static java.util.Collections.EMPTY_MAP;
+import static org.easymock.EasyMock.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the HystrixClientErrorHandler.
+ * @author chris.phillips
+ */
+public class TestHystrixClientErrorHandler {
+
+    private static final String CAUSE = "cause";
+
+    private ClientErrorHandler clientErrorHandler = createMock(ClientErrorHandler.class);
+
+    @SuppressWarnings("unchecked")
+    private HystrixClientErrorHandler errorHandler = new HystrixClientErrorHandler(EMPTY_MAP, this.clientErrorHandler);
+
+    private final Method method = TestHystrixClientErrorHandler.class.getMethods()[0];
+    private final Map<Method, ? extends BadRequestCriteria> criteriaMap = ImmutableMap.of(method, new BadRequestCriteria() {
+        @Override
+        public boolean apply(BaseClientResponse response, Exception exception) {
+            return response.getStatus() == HttpResponseCodes.SC_NOT_FOUND;
+        }
+    });
+
+    private void prepareHandler(BaseClientResponse response, RuntimeException ex, RuntimeException toThrow) {
+        this.clientErrorHandler.clientErrorHandling(this.method, response, ex);
+        expectLastCall().andThrow(toThrow);
+        replay(this.clientErrorHandler);
+    }
+
+    @Test
+    public void defaultBadRequestNoInterceptors() {
+        RuntimeException cause = new RuntimeException(CAUSE);
+        BaseClientResponse response = dummyResponse(HttpResponseCodes.SC_BAD_REQUEST);
+        prepareHandler(response, cause, cause);
+        ensureBadRequestException(this.errorHandler, response, cause);
+    }
+
+    @Test(expected = ClientResponseFailure.class)
+    public void defaultFailedRequestNoInterceptors() {
+        BaseClientResponse response = dummyResponse(HttpResponseCodes.SC_INTERNAL_SERVER_ERROR);
+        ClientResponseFailure cause = new ClientResponseFailure(response);
+        prepareHandler(response, cause, cause);
+        ensureFailure(this.errorHandler, response, cause);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void defaultNullResponse() {
+        IllegalStateException cause = new IllegalStateException(CAUSE);
+        prepareHandler(null, cause, cause);
+        ensureFailure(this.errorHandler, null, cause);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void defaultFailedRequestInterceptorThrows() {
+        @SuppressWarnings("unchecked")
+        HystrixClientErrorHandler hystrixClientErrorHandler = new HystrixClientErrorHandler(EMPTY_MAP, this.clientErrorHandler);
+        BaseClientResponse response = dummyResponse(HttpResponseCodes.SC_INTERNAL_SERVER_ERROR);
+        ClientResponseFailure cause = new ClientResponseFailure(response);
+        prepareHandler(response, cause, new IllegalArgumentException());
+        ensureFailure(hystrixClientErrorHandler, response, cause);
+    }
+
+    @Test(expected = ClientResponseFailure.class)
+    public void customFailedRequestNoInterceptor() {
+        @SuppressWarnings("unchecked")
+        HystrixClientErrorHandler hystrixClientErrorHandler = new HystrixClientErrorHandler(criteriaMap, this.clientErrorHandler);
+        // response that doesn't match the configured criteria
+        BaseClientResponse response = dummyResponse(HttpResponseCodes.SC_INTERNAL_SERVER_ERROR);
+        ClientResponseFailure cause = new ClientResponseFailure(response);
+        prepareHandler(response, cause, cause);
+        ensureFailure(hystrixClientErrorHandler, response, cause);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void customFailedRequestInterceptorThrows() {
+        HystrixClientErrorHandler hystrixClientErrorHandler = new HystrixClientErrorHandler(this.criteriaMap, this.clientErrorHandler);
+        // response that doesn't match the configured criteria
+        BaseClientResponse response = dummyResponse(HttpResponseCodes.SC_INTERNAL_SERVER_ERROR);
+        ClientResponseFailure cause = new ClientResponseFailure(response);
+        prepareHandler(response, cause, new IllegalArgumentException());
+        ensureFailure(hystrixClientErrorHandler, response, cause);
+    }
+
+    @Test
+    public void customBadRequestInterceptorThrows() {
+        HystrixClientErrorHandler hystrixClientErrorHandler = new HystrixClientErrorHandler(this.criteriaMap, this.clientErrorHandler);
+        BaseClientResponse response = dummyResponse(HttpResponseCodes.SC_NOT_FOUND);
+        ClientResponseFailure cause = new ClientResponseFailure(CAUSE, response);
+        prepareHandler(response, cause, new IllegalArgumentException(CAUSE));
+        ensureBadRequestException(hystrixClientErrorHandler, response, cause);
+    }
+
+    @Test
+    public void customBadRequestNoInterceptors() {
+        @SuppressWarnings("unchecked")
+        HystrixClientErrorHandler hystrixClientErrorHandler = new HystrixClientErrorHandler(this.criteriaMap, this.clientErrorHandler);
+        BaseClientResponse response = dummyResponse(HttpResponseCodes.SC_NOT_FOUND);
+        ClientResponseFailure cause = new ClientResponseFailure(CAUSE, response);
+        prepareHandler(response, cause, cause);
+        ensureBadRequestException(hystrixClientErrorHandler, response, cause);
+    }
+
+    private void ensureBadRequestException(HystrixClientErrorHandler hystrixClientErrorHandler, BaseClientResponse response,
+                                           RuntimeException cause) {
+        try {
+            hystrixClientErrorHandler.clientErrorHandling(method, response, cause);
+            fail();
+        } catch (HystrixBadRequestException ex) {
+            assertThat(ex.getCause().getMessage(), is(CAUSE));
+        }
+    }
+
+    private void ensureFailure(HystrixClientErrorHandler hystrixClientErrorHandler, BaseClientResponse response,
+                               RuntimeException cause) {
+        try {
+            hystrixClientErrorHandler.clientErrorHandling(method, response, cause);
+            fail();
+        } catch (HystrixBadRequestException ex) {
+            fail();
+        }
+    }
+
+    private BaseClientResponse dummyResponse(int status) {
+        BaseClientResponse clientResponse = new BaseClientResponse(new BaseClientResponse.BaseClientResponseStreamFactory() {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return null;
+            }
+
+            @Override
+            public void performReleaseConnection() {
+
+            }
+        }, Client.DEFAULT_ERROR_STATUS_CRITERIA);
+        clientResponse.setStatus(status);
+        return clientResponse;
+    }
+}

--- a/rest-client-test/src/main/java/com/opower/rest/test/StatusCodeMatcher.java
+++ b/rest-client-test/src/main/java/com/opower/rest/test/StatusCodeMatcher.java
@@ -1,0 +1,62 @@
+package com.opower.rest.test;
+
+import javax.ws.rs.core.Response;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Used for testing error handling logic with an ExpectedException Rule.
+ * @author chris.phillips
+ */
+public class StatusCodeMatcher extends BaseMatcher<StatusCodeMatcher.ResponseError> {
+    private final int expectedCode;
+
+    /**
+     * Creates an instance that expects the given status code.
+     * @param expectedCode the expected status code.
+     */
+    public StatusCodeMatcher(int expectedCode) {
+        this.expectedCode = expectedCode;
+    }
+
+    @Override
+    public boolean matches(Object error) {
+        return getValue(error) == this.expectedCode;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendValue(this.expectedCode);
+    }
+
+    @Override
+    public void describeMismatch(Object error, Description description) {
+        description.appendText("was ").appendValue(getValue(error));
+    }
+
+    private int getValue(Object error) {
+        return ((ResponseError) checkNotNull(error)).getClientResponse().getStatus();
+    }
+
+    /**
+     * A class that wraps up the Response without having to worry about the baggage of BaseClientResponse.
+     */
+    public static class ResponseError extends RuntimeException {
+        private final Response clientResponse;
+
+        /**
+         * Create a ResponseError to hold the given Response instance.
+         * @param clientResponse the Response to use
+         */
+        public ResponseError(Response clientResponse) {
+            this.clientResponse = checkNotNull(clientResponse);
+        }
+
+        public Response getClientResponse() {
+            return this.clientResponse;
+        }
+    }
+}

--- a/rest-client-test/src/main/java/com/opower/rest/test/resource/FrobResource.java
+++ b/rest-client-test/src/main/java/com/opower/rest/test/resource/FrobResource.java
@@ -84,9 +84,10 @@ public interface FrobResource {
 
     /**
      * Used for testing logic in ClientErrorHandler.
+     * @param status the status code you want on the response
      * @return a dummy Frob
      */
     @GET
     @Path("errorcode")
-    Frob frobErrorResponse();
+    Frob frobErrorResponse(@QueryParam("status")int status);
 }

--- a/rest-client-test/src/main/java/com/opower/rest/test/resource/FrobServerResource.java
+++ b/rest-client-test/src/main/java/com/opower/rest/test/resource/FrobServerResource.java
@@ -20,6 +20,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
 import java.util.concurrent.ExecutionException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -74,7 +75,7 @@ public class FrobServerResource implements FrobResource {
     }
 
     @Override
-    public Frob frobErrorResponse() {
-        throw new RuntimeException("bork");
+    public Frob frobErrorResponse(int status) {
+        throw new WebApplicationException(Response.Status.fromStatusCode(status));
     }
 }


### PR DESCRIPTION
Refactored the ClientErrorHandler:
    * extracted the interface
    * allow builder subclasses to provide their own ClientErrorHandler
    * created the HystrixClientErrorHandler:  exceptions that are matched by the BadRequestCriteria are wrapped in a HystrixBadRequestException
    * The HystrixClientErrorHandler keeps a Map<Method, ? extends BadRequestCriteria> so that each method on the resource interface can define it's own criteria for mapping response / exceptions --> HystrixBadRequestException
    * HystrixClient provides methods for specifying the BadRequestCriteria at the resource level and also at the method level
    * also added validation to the HystrixClient to make sure that when calling the per-resource-method config methods, it requires that the method passed in be from the Resource interface
    * refactored the ProxyCommand class to unwrap InvocationTargetExceptions before throwing

 Refactored Test code to support good coverage of the error handling.
   * moved the int test surefire execution to the parent pom to allow it to run in all the projects if necessary.
   * tweaked error response method on FrobResource to return the status code passed in

Added unit and integration tests for A variety of error handling scenarios