### PR TITLE
fixes bug in HystrixClient.Builder 

### DIFF
--- a/rest-client-hystrix/pom.xml
+++ b/rest-client-hystrix/pom.xml
@@ -38,6 +38,12 @@
             <version>1.1.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Potentially confusing exception when resource method specific configuration was set more than once.

The underlying ImmutableMap.Builder would throw an Exception about there being a duplicate key. This fix makes it so that instead of throwing an Exception, it lets the last value win which seems to be the least surprising way to handle it.